### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*


### PR DESCRIPTION
# WHAT
gitignoreファイルにpublic/uploads/*を追加
# WHY
public/uploadsをgitの追跡対象から外すため